### PR TITLE
Přidáno chybějící (nepovinné) pole received_on na přijatých dokladech

### DIFF
--- a/Altairis.Fakturoid.Client/JsonExpense.cs
+++ b/Altairis.Fakturoid.Client/JsonExpense.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Altairis.Fakturoid.Client {
@@ -91,6 +91,11 @@ namespace Altairis.Fakturoid.Client {
         /// Datum vystavení (zobrazeno na faktuře)
         /// </summary>
         public DateTime? issued_on { get; set; }
+
+        /// <summary>
+        /// Datum přijetí (nepovinné - doplní se dle duzp)
+        /// </summary>
+        public DateTime? received_on { get; set; }
 
         /// <summary>
         /// Datum zdanitelného plnění (nepovinné - doplní se dnes)


### PR DESCRIPTION
Přidal jsem novou property received_on na JsonExpense. Property není dokumentovaná v Apiary, má ale podporu v API a je důležitá pro přijaté doklady. Property reprezentuje datum přijetí dokladu, které je rozhodné při vytváření přiznání k DPH.