### PR TITLE
Oprava názvu parametru (paid_at na paid_on)

### DIFF
--- a/Altairis.Fakturoid.Client/FakturoidExpensesProxy.cs
+++ b/Altairis.Fakturoid.Client/FakturoidExpensesProxy.cs
@@ -343,7 +343,7 @@ namespace Altairis.Fakturoid.Client {
             string urlFormat;
             switch (status) {
                 case ExpensePaymentStatus.Paid:
-                    urlFormat = "expenses/{0}/fire.json?event=pay&paid_at=" + Uri.EscapeDataString(XmlConvert.ToString(effectiveDate, XmlDateTimeSerializationMode.RoundtripKind));
+                    urlFormat = "expenses/{0}/fire.json?event=pay&paid_on=" + Uri.EscapeDataString(XmlConvert.ToString(effectiveDate, XmlDateTimeSerializationMode.RoundtripKind));
                     break;
                 default:
                     urlFormat = "expenses/{0}/fire.json?event=remove_payment";


### PR DESCRIPTION
Název parametru paid_ad byl chybný a ignorován v API. Při nastavení data úhrady faktury se proto datum ignorovalo a nastavilo na datetime.now. Ověřeno s vývojáři fakturoidu.